### PR TITLE
Change slides to hidden to prevent loading.

### DIFF
--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -29,27 +29,27 @@
           <img id="philadelphia-photo" src="/images/places-0.jpg" alt="Philadelphia, PA" width="600px">
           <label for="philadelphia-photo" class="caption">Philadelphia</label>
         </div>
-        <div class="my-slides">
+        <div class="my-slides" hidden="true">
           <img id="delaware-photo" src="/images/places-1.jpg" alt="Lewes, DE" width="600px">
           <label for="delaware-photo" class="caption">Lewes, Delaware</label>
         </div>
-        <div class="my-slides">
+        <div class="my-slides" hidden="true">
           <img id="golden-gate-bridge-photo" src="/images/places-2.jpg" alt="Golden Gate Bridge" width="600px">
           <label for="golden-gate-bridge-photo" class="caption">Golden Gate Bridge</label>
         </div>
-        <div class="my-slides">
+        <div class="my-slides" hidden="true">
           <img id="fort-mason-photo" src="/images/places-3.jpg" alt="Fort Mason" width="600px">
           <label for="fort-mason-photo" class="caption">Fort Mason</label>
         </div>
-        <div class="my-slides">
+        <div class="my-slides" hidden="true">
           <img id="oracle-park-photo" src="/images/places-4.jpg" alt="Oracle Park" width="600px">
           <label for="oracle-park-photo" class="caption">Oracle Park</label>
         </div>
-        <div class="my-slides">
+        <div class="my-slides" hidden="true">
           <img id="monte-cristi-photo" src="/images/places-5.jpg" alt="Monte Cristi, Dominican Republic" width="600px">
           <label for="monte-cristi-photo" class="caption">Monte Cristi, DR</label>
         </div>
-        <div class="my-slides">
+        <div class="my-slides" hidden="true">
           <img id="avienda-el-morro-photo" src="/images/places-6.jpg" alt="Avienda El Morro, Dominican Republic" width="600px">
           <label for="avienda-el-morro-photo" class="caption">Avienda El Morro, DR</label>
         </div>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -25,6 +25,7 @@ function slideShow(imgIndex = 0) {
   }
   
   for (let slide of slides) {
+    slide.hidden = true;
     slide.style.display = 'none';
   }
   
@@ -33,6 +34,7 @@ function slideShow(imgIndex = 0) {
     imgIndex = 0;
   }
   
+  slides[imgIndex].hidden = false;
   slides[imgIndex].style.display = '';
 
   // Delay next function call so image is displayed for 5 seconds.


### PR DESCRIPTION
Set all slides except the first one to default to hidden. Now, the first image shows up while everything else is loading and none of the other images are visible at all when page is loading.