### PR TITLE
Optimize query

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -98,21 +98,26 @@ public final class FindMeetingQuery {
     for (Map.Entry entry : optionalBusyTimesMap.entrySet()) {
       List<TimeRange> freeTimes = findFreeTimes((Collection<TimeRange>) entry.getValue(), meetingDuration);
       for (TimeRange freeRange : freeTimes) {
-        for (int i = numOptionalAttendees - 1; i >= 0; i--) {
-          for (TimeRange existingRange : optionalFreeTimes.get(i)) {
-            TimeRange intersection = freeRange.intersection(existingRange);
-            if (i < numOptionalAttendees - 1 && 
-                intersection != null && intersection.duration() >= meetingDuration) {
-              optionalFreeTimes.get(i + 1).add(intersection);
-            }
-          }
-          if (i == 0) {
-            optionalFreeTimes.get(i).add(freeRange);
-          }
-        }
+        addToFreeTimesList(optionalFreeTimes, freeRange, numOptionalAttendees, meetingDuration);
       }
     }
     return optionalFreeTimes;
+  }
+
+  // Adds a time range to a nested list at the appropriate index.
+  private static void addToFreeTimesList(
+      List<List<TimeRange>> optionalFreeTimes, TimeRange freeRange, int numOptionalAttendees, long meetingDuration) {
+    for (int i = numOptionalAttendees - 2; i >= 0; i--) {
+      for (TimeRange existingRange : optionalFreeTimes.get(i)) {
+        TimeRange intersection = freeRange.intersection(existingRange);
+        if (intersection != null && intersection.duration() >= meetingDuration) {
+          optionalFreeTimes.get(i + 1).add(intersection);
+        }
+      }
+    }
+    if (!optionalFreeTimes.isEmpty()) {
+      optionalFreeTimes.get(0).add(freeRange);
+    }
   }
 
   // Finds all intersections of time ranges that are at least as long as the meeting duration.

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -73,10 +73,24 @@ public final class FindMeetingQuery {
     return mandatoryFreeTimes;
   }
 
+  /**
+   * Determines if two collections of attendees have any attendees in common.
+   *
+   * @param eventAttendees    a collection of attendees for a certain event
+   * @param requestAttendees  a collection of the requested attendees for the meeting
+   * @return                  whether or not the two collections have at least one attendee in common
+   */
   private static boolean hasCommonAttendees(Collection<String> eventAttendees, Collection<String> requestAttendees) {
     return !Collections.disjoint(eventAttendees, requestAttendees);
   }
 
+  /**
+   * Finds all common attendees between two collections.
+   *
+   * @param eventAttendees    a collection of attendees for a certain event
+   * @param requestAttendees  a collection of the requested attendees for the meeting
+   * @return                  a collection of all the attendees that are in both collections
+   */
   private static Collection<String> getCommonAttendees(Collection<String> eventAttendees, Collection<String> requestAttendees) {
     Collection<String> commonAttendees = new HashSet<>();
     for (String person : eventAttendees) {
@@ -87,7 +101,14 @@ public final class FindMeetingQuery {
     return commonAttendees;
   }
 
-  // Returns a nested list where the index of each list represents that index + 1 optional attendees can attend those times.
+  /**
+   * Creates a nested list where the index i of each list represents that 
+   * i + 1 optional attendees can attend the times listed at that index.
+   *
+   * @param optionalBusyTimesMap  maps each optional attendee's name to a set of the time ranges when they are busy
+   * @param meetingDuration       length of the requested meeting
+   * @return                      a nested list containing each time range at its corresponding index
+   */
   private static List<List<TimeRange>> makeOptionalFreeTimesList(
       Map<String, Set<TimeRange>> optionalBusyTimesMap, long meetingDuration) {
     List<List<TimeRange>> optionalFreeTimes = new ArrayList<>();
@@ -104,7 +125,14 @@ public final class FindMeetingQuery {
     return optionalFreeTimes;
   }
 
-  // Adds a time range to a nested list at the appropriate index.
+  /**
+   * Adds a free time range to a nested list at the appropriate index.
+   *
+   * @param optionalFreeTimes     nested list to add the time range to
+   * @param freeRange             time range to be added
+   * @param numOptionalAttendees  total number of optional attendees
+   * @param meetingDuration       length of the requested meeting
+   */
   private static void addToFreeTimesList(
       List<List<TimeRange>> optionalFreeTimes, TimeRange freeRange, int numOptionalAttendees, long meetingDuration) {
     for (int i = numOptionalAttendees - 2; i >= 0; i--) {
@@ -120,7 +148,14 @@ public final class FindMeetingQuery {
     }
   }
 
-  // Finds all intersections of time ranges that are at least as long as the meeting duration.
+  /**
+   * Finds all intersections of time ranges that are at least as long as the requested meeting duration.
+   *
+   * @param mandatoryFreeTimes  list of time ranges when all mandatory attendees are free
+   * @param optionalFreeTimes   list of times when optional attendees are free
+   * @param meetingDuration     length of requested meeting
+   * @return                    a list containing the intersections between the two lists
+   */
   private static List<TimeRange> findIntersectionFreeTimes(
       List<TimeRange> mandatoryFreeTimes, List<TimeRange> optionalFreeTimes, long meetingDuration) {
     List<TimeRange> bothFreeTimes = new ArrayList<>();
@@ -141,8 +176,13 @@ public final class FindMeetingQuery {
     return bothFreeTimes;
   }
 
-  // Merges a new time range with existing time range in collection, if necessary.
-  // Returns whether or not the time range was merged.
+  /**
+   * Merges a new time range with an overlapping time range in the collection, if possible.
+   * 
+   * @param busyTimes   collection to be altered that contains time intervals that can be merged
+   * @param eventTime   new time range to be merged
+   * @return            whether or not the time range was merged
+   */
   private static boolean addToBusySet(Collection<TimeRange> busyTimes, TimeRange eventTime) {
     Iterator iterator = busyTimes.iterator();
     while (iterator.hasNext()) {
@@ -167,8 +207,13 @@ public final class FindMeetingQuery {
     return false;
   }
 
-  // Takes in a collection of busy time ranges to find all free time ranges based on duration of the meeting.
-  // Returns all possibilities as a list.
+  /**
+   * Takes in a collection of busy time ranges to find all free time ranges based on duration of the meeting.
+   * 
+   * @param busyTimes        collection of busy time ranges
+   * @param meetingDuration  length of requested meeting
+   * @return                 a list containing all free time ranges for the meeting
+   */
   private static List<TimeRange> findFreeTimes(Collection<TimeRange> busyTimes, long meetingDuration) {
     List<TimeRange> busyTimesList = new ArrayList<>(busyTimes);
     Collections.sort(busyTimesList, TimeRange.ORDER_BY_START);

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -18,14 +18,16 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public final class FindMeetingQuery {
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
     Set<TimeRange> busyTimes = new HashSet<>();
-    Set<TimeRange> optionalAttendeeEventTimes = new HashSet<>();
+    Map<String, Set<TimeRange>> optionalBusyTimes = new HashMap<>();
     for (Event event : events) {
       TimeRange eventTime = event.getWhen();
       if (hasCommonAttendees(event.getAttendees(), request.getAttendees())) {
@@ -34,33 +36,109 @@ public final class FindMeetingQuery {
           busyTimes.add(eventTime);
         }
       } else if (hasCommonAttendees(event.getAttendees(), request.getOptionalAttendees())) {
-        boolean added = addToBusySet(optionalAttendeeEventTimes, eventTime);
-        if (!added) {
-          optionalAttendeeEventTimes.add(eventTime);
+        Collection<String> commonAttendees = getCommonAttendees(event.getAttendees(), request.getOptionalAttendees());
+        // Maps each optional attendee to a set of their busy times.
+        for (String attendee : commonAttendees) {
+          Set<TimeRange> times = optionalBusyTimes.getOrDefault(attendee, new HashSet<TimeRange>());
+          boolean added = addToBusySet(times, eventTime);
+          if (!added) {
+            times.add(eventTime);
+          }
+          optionalBusyTimes.put(attendee, times);
         }
       }
     }
 
-    List<TimeRange> optionalFreeTimes = findFreeTimes(optionalAttendeeEventTimes, request.getDuration());
     List<TimeRange> mandatoryFreeTimes = findFreeTimes(busyTimes, request.getDuration());
-
-    if (request.getAttendees().size() == 0) {
-      return optionalFreeTimes;
-    } else if (request.getOptionalAttendees().size() == 0) {
+    if (optionalBusyTimes.size() == 0) {
       return mandatoryFreeTimes;
     }
 
-    Collection<TimeRange> bothFreeTimes = findIntersectionFreeTimes(mandatoryFreeTimes, optionalFreeTimes, request.getDuration());
-    return bothFreeTimes.size() > 0 ? bothFreeTimes : mandatoryFreeTimes;
+    Map<String, List<TimeRange>> optionalFreeTimesMap = makeFreeTimesMap(optionalBusyTimes, request.getDuration());
+
+    List<List<TimeRange>> optionalFreeTimes = makeOptionalFreeTimesList(optionalFreeTimesMap, request.getDuration());
+    
+    Collection<TimeRange> bothFreeTimes;
+    for (int i = optionalFreeTimes.size() - 1; i >= 0; i--) {
+      for (TimeRange time : optionalFreeTimes.get(i)) {
+        System.out.println("free: " + time);
+      }
+      if (request.getAttendees().size() == 0 && optionalFreeTimes.get(i).size() != 0) {
+        return optionalFreeTimes.get(i);
+      }
+      bothFreeTimes = findIntersectionFreeTimes(mandatoryFreeTimes, optionalFreeTimes.get(i), request.getDuration());
+      if (bothFreeTimes.size() > 0) {
+        return bothFreeTimes;
+      }
+    }
+    return mandatoryFreeTimes;
   }
 
   private static boolean hasCommonAttendees(Collection<String> eventAttendees, Collection<String> requestAttendees) {
     return !Collections.disjoint(eventAttendees, requestAttendees);
   }
 
+  private static Collection<String> getCommonAttendees(Collection<String> eventAttendees, Collection<String> requestAttendees) {
+    Collection<String> commonAttendees = new HashSet<>();
+    for (String person : eventAttendees) {
+      if (requestAttendees.contains(person)) {
+        commonAttendees.add(person);
+      }
+    }
+    return commonAttendees;
+  }
+
+  // At index i of optionalFreeTimes, i + 1 optional attendees can attend any of the given time ranges.
+  private static List<List<TimeRange>> makeOptionalFreeTimesList(
+      Map<String, List<TimeRange>> optionalFreeTimesMap, long meetingDuration) {
+    List<List<TimeRange>> optionalFreeTimes = new ArrayList<>();
+    int numOptionalAttendees = optionalFreeTimesMap.size();
+    for (int i = 0; i < numOptionalAttendees; i++) {
+      optionalFreeTimes.add(new ArrayList<TimeRange>());
+    }
+    for (Map.Entry entry : optionalFreeTimesMap.entrySet()) {
+      List<TimeRange> currRanges = (List<TimeRange>) entry.getValue();
+      for (TimeRange range : currRanges) {
+        for (int i = numOptionalAttendees - 1; i >= 0; i--) {
+          for (TimeRange existingRange : optionalFreeTimes.get(i)) {
+            TimeRange intersection = intersection(range, existingRange);
+            if (i < numOptionalAttendees - 1 && 
+                intersection != null && intersection.duration() >= meetingDuration) {
+              optionalFreeTimes.get(i + 1).add(intersection);
+            }
+          }
+          if (i == 0) {
+            optionalFreeTimes.get(i).add(range);
+          }
+        }
+      }
+    }
+    return optionalFreeTimes;
+  }
+
+  // Maps each optional attendee to a list of their free times.
+  private static Map<String, List<TimeRange>> makeFreeTimesMap(
+      Map<String, Set<TimeRange>> optionalBusyTimes, long meetingDuration) {
+    HashMap<String, List<TimeRange>> optionalFreeTimesMap = new HashMap<>();
+    for (Map.Entry entry : optionalBusyTimes.entrySet()) {
+      String attendeeName = (String) entry.getKey();
+
+      System.out.println(attendeeName);
+
+      Set<TimeRange> attendeeBusyTimes = (Set<TimeRange>) entry.getValue();
+
+      for (TimeRange time : attendeeBusyTimes) {
+        System.out.println("busy: " + time);
+      }
+
+      optionalFreeTimesMap.put(attendeeName, findFreeTimes(attendeeBusyTimes, meetingDuration));
+    }
+    return optionalFreeTimesMap;
+  }
+
   // Finds all intersections of time ranges that are at least as long as the meeting duration.
   private static Collection<TimeRange> findIntersectionFreeTimes(
-    List<TimeRange> mandatoryFreeTimes, List<TimeRange> optionalFreeTimes, long meetingDuration) {
+      List<TimeRange> mandatoryFreeTimes, List<TimeRange> optionalFreeTimes, long meetingDuration) {
     Collection<TimeRange> bothFreeTimes = new ArrayList<>();
     for (TimeRange optionalTime : optionalFreeTimes) {
       Iterator iterator = mandatoryFreeTimes.iterator();
@@ -98,7 +176,7 @@ public final class FindMeetingQuery {
           busyTimes.add(TimeRange.fromStartEnd(currRange.start(), eventTime.end(), /* inclusive= */ false));
         } else {
           busyTimes.remove(currRange);
-          busyTimes.add(TimeRange.fromStartEnd(eventTime.start(), currRange.end(), /* inclusive= */ true));
+          busyTimes.add(TimeRange.fromStartEnd(eventTime.start(), currRange.end(), /* inclusive= */ false));
         }
         return true;
       }
@@ -140,9 +218,9 @@ public final class FindMeetingQuery {
       return t1;
     } else {
       if (t1.start() > t2.start()) {
-        return TimeRange.fromStartEnd(t1.start(), t2.end(), /* inclusive= */ true);
+        return TimeRange.fromStartEnd(t1.start(), t2.end(), /* inclusive= */ false);
       } else {
-        return TimeRange.fromStartEnd(t2.start(), t1.end(), /* inclusive= */ true);
+        return TimeRange.fromStartEnd(t2.start(), t1.end(), /* inclusive= */ false);
       }
     }
   }

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -330,7 +330,7 @@ public final class FindMeetingQueryTest {
     Collection<TimeRange> expected =
         Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
             TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
-
+    
     Assert.assertEquals(expected, actual);
   }
 
@@ -348,7 +348,7 @@ public final class FindMeetingQueryTest {
             Arrays.asList(PERSON_A)),
         new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
             Arrays.asList(PERSON_A)),
-        new Event("Event 3", TimeRange.fromStartEnd(TIME_0830AM, TIME_0845AM, true),
+        new Event("Event 3", TimeRange.fromStartEnd(TIME_0830AM, TIME_0845AM, false),
             Arrays.asList(PERSON_B)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
@@ -363,7 +363,6 @@ public final class FindMeetingQueryTest {
 
   @Test
   public void onlyOptionalAttendeesAllConsidered() {
-
     // Have each person have different events. We should see two options because each person has
     // split the restricted times.
     //
@@ -393,7 +392,7 @@ public final class FindMeetingQueryTest {
   @Test
   public void onlyOptionalAttendeesNoSpaces() {
     // Have each person have events the whole day. 
-    // We should see no options because there is no available time.
+    // We should see two options because the optimized solution would have one attendee.
     //
     // Events  : |-----A-----|
     //                   |----------B----------|
@@ -401,7 +400,7 @@ public final class FindMeetingQueryTest {
     // Options : 
 
     Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_1100AM, true),
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_1100AM, false),
             Arrays.asList(PERSON_A)),
         new Event("Event 2", TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true),
             Arrays.asList(PERSON_B)));
@@ -412,7 +411,40 @@ public final class FindMeetingQueryTest {
     request.addOptionalAttendee(PERSON_B);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected = Arrays.asList();
+    Collection<TimeRange> expected = Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_1000AM, false),
+        TimeRange.fromStartEnd(TIME_1100AM, TimeRange.END_OF_DAY, true));
+    
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void optionalAttendeesSomeConsidered() {
+    // Have A mandatory attendee and B and C optional, where C is busy all day. 
+    // We should see only options for where A and B are free.
+    //
+    // Events  :       |--A--|     |--B--|
+    //           |--------------C--------------|
+    // Day     : |-----------------------------|
+    // Options : |--1--|     |--2--|     |--3--|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event("Event 3", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_B);
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
 
     Assert.assertEquals(expected, actual);
   }

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -448,5 +448,34 @@ public final class FindMeetingQueryTest {
 
     Assert.assertEquals(expected, actual);
   }
+
+  @Test
+  public void optionalAttendeesOverlapping() {
+    // Have A mandatory attendee and B and C optional. 
+    // We should see two overlapping options, one for A and C and one for A and B.
+    //
+    // Events  : |----A----|--B--|
+    //                                 |---C---|
+    // Day     : |-----------------------------|
+    // Options :           |-----1-----|
+    //                            |------2-----|
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0900AM, false),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event("Event 3", TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_C)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_60_MINUTES);
+    request.addOptionalAttendee(PERSON_B);
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TIME_0900AM, TIME_1000AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+    Assert.assertEquals(expected, actual);
+  }
 }
 


### PR DESCRIPTION
Current optimization query approach: 
- store each optional attendee's events (busy times) in a map (where the key is attendee name and val is a list of their events)
- use this to create a nested list where each index i has a list of time ranges that i + 1 optional attendees can make it to
- iterate backwards through the nested list, comparing these optional free time ranges to the free time ranges for mandatory attendees
    - return the intersection of optional and free time ranges the first time they overlap

Seems to work at least with the tests I wrote but is very inefficient (lots of nested loops) :(